### PR TITLE
Fix TypeError in Curriculum.test.tsx

### DIFF
--- a/src/pages/__tests__/Curriculum.test.tsx
+++ b/src/pages/__tests__/Curriculum.test.tsx
@@ -1,11 +1,9 @@
-// File: /src/pages/__tests__/Curriculum.test.tsx
-// Description: Unit test for Curriculum page component.
-
 import React from 'react';
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from "../../test/testUtils";
 import Curriculum from "../Curriculum";
+import { MyProvider } from '../../contexts/MyContext';
 
 interface MockAuthState {
   loginWithGoogle: jest.Mock;
@@ -36,7 +34,9 @@ describe('Curriculum Component', () => {
 
   // Test Cases
   const renderComponent = (): React.ReactElement => (
-    <Curriculum />
+    <MyProvider>
+      <Curriculum />
+    </MyProvider>
   );
 
   it("renders main curriculum content", async () => {


### PR DESCRIPTION
Fix the `TypeError: Cannot read properties of undefined (reading 'Provider')` in the `src/pages/__tests__/Curriculum.test.tsx` file.

* Import `MyProvider` from `src/contexts/MyContext`.
* Wrap the `Curriculum` component with `MyProvider` in the `renderComponent` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Geaux-Specialist-L-L-C/GA-MVP/pull/47?shareId=abbadd82-0764-4dc0-892f-5193f9c12509).