### PR TITLE
Align AuthContext with UI auth API and wire Firebase sign-in/out

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -12,7 +12,7 @@ interface LocationState {
 }
 
 const Login: React.FC = (): JSX.Element => {
-  const { login, error } = useAuth();
+  const { login, loginWithGoogle, error } = useAuth();
   const navigate = useNavigate();
   const location = useLocation() as Location & { state: LocationState };
   const [formData, setFormData] = useState({ email: "", password: "" });
@@ -25,7 +25,7 @@ const Login: React.FC = (): JSX.Element => {
   const handleGoogleLogin = async (): Promise<void> => {
     try {
       setLoading(true);
-      await login();
+      await loginWithGoogle();
       navigate('/dashboard');
     } catch (err) {
       console.error("Login error:", err);
@@ -38,7 +38,7 @@ const Login: React.FC = (): JSX.Element => {
     e.preventDefault();
     try {
       setLoading(true);
-      await login();
+      await login(formData.email, formData.password);
       navigate('/dashboard');
     } catch (err) {
       console.error("Login error:", err);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -60,7 +60,7 @@ const LoginForm: React.FC = (): JSX.Element => {
 
   const handleLogin = async (): Promise<void> => {
     try {
-      await login();
+      await login(email, password);
       navigate('/dashboard');
     } catch (err) {
       console.error('Login error:', err);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,58 +1,120 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
-import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createUserWithEmailAndPassword, onAuthStateChanged, signInWithEmailAndPassword, User, UserCredential } from 'firebase/auth';
+import { auth } from '../config/firebase';
+import { firebaseService } from '../services/firebaseService';
+import type { AuthContextType } from '../types/auth';
 
-export interface AuthContextProps {
-  currentUser: User | null;
-  isLoading: boolean;
-  error: Error | null;
-}
+export type AuthContextProps = AuthContextType;
 
-const AuthContext = createContext<AuthContextProps>({
+export const AuthContext = createContext<AuthContextProps>({
   currentUser: null,
+  user: null,
+  loading: true,
   isLoading: true,
-  error: null
+  isAuthReady: false,
+  error: null,
+  login: async () => {
+    throw new Error('AuthProvider not initialized');
+  },
+  loginWithGoogle: async () => {
+    throw new Error('AuthProvider not initialized');
+  },
+  signup: async () => {
+    throw new Error('AuthProvider not initialized');
+  },
+  logout: async () => {
+    throw new Error('AuthProvider not initialized');
+  },
+  clearError: () => undefined
 });
 
 export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isAuthReady, setIsAuthReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    try {
-      const auth = getAuth();
-      const unsubscribe = onAuthStateChanged(auth, 
-        (user) => {
-          setCurrentUser(user);
-          setIsLoading(false);
-          setError(null);
-        },
-        (error) => {
-          console.error('Auth state change error:', error);
-          setError(error);
-          setIsLoading(false);
-        }
-      );
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (user) => {
+        setCurrentUser(user);
+        setLoading(false);
+        setIsAuthReady(true);
+        setError(null);
+      },
+      (authError) => {
+        console.error('Auth state change error:', authError);
+        setError(authError instanceof Error ? authError.message : 'Failed to determine auth state');
+        setLoading(false);
+        setIsAuthReady(true);
+      }
+    );
 
-      return unsubscribe;
-    } catch (err) {
-      console.error('Auth initialization error:', err);
-      setError(err instanceof Error ? err : new Error('Failed to initialize auth'));
-      setIsLoading(false);
-    }
+    return unsubscribe;
   }, []);
 
+  const clearError = () => setError(null);
+
+  const runWithAuthState = async <T,>(
+    action: () => Promise<T>,
+    fallbackMessage: string
+  ): Promise<T> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await action();
+    } catch (authError) {
+      const message =
+        authError instanceof Error ? authError.message : fallbackMessage;
+      setError(message);
+      throw authError instanceof Error ? authError : new Error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const login = (email: string, password: string): Promise<UserCredential> =>
+    runWithAuthState(
+      () => signInWithEmailAndPassword(auth, email, password),
+      'Failed to log in'
+    );
+
+  const signup = (email: string, password: string): Promise<UserCredential> =>
+    runWithAuthState(
+      () => createUserWithEmailAndPassword(auth, email, password),
+      'Failed to sign up'
+    );
+
+  const loginWithGoogle = (): Promise<void> =>
+    runWithAuthState(async () => {
+      await firebaseService.signInWithGoogle();
+    }, 'Failed to sign in with Google');
+
+  const logout = (): Promise<void> =>
+    runWithAuthState(async () => {
+      await firebaseService.signOut();
+    }, 'Failed to log out');
+
   return (
-    <AuthContext.Provider value={{ currentUser, isLoading, error }}>
-      {error ? (
-        <div role="alert" style={{ color: 'red', padding: '1rem' }}>
-          Authentication Error: {error.message}
-        </div>
-      ) : (
-        children
-      )}
+    <AuthContext.Provider
+      value={{
+        currentUser,
+        user: currentUser,
+        loading,
+        isLoading: loading,
+        isAuthReady,
+        error,
+        login,
+        loginWithGoogle,
+        signup,
+        logout,
+        clearError
+      }}
+    >
+      {children}
     </AuthContext.Provider>
   );
 };

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -22,14 +22,14 @@ interface Course {
 
 const Curriculum: React.FC = () => {
   const [selectedGrade, setSelectedGrade] = useState<'elementary' | 'middle' | 'high'>('middle');
-  const { login } = useAuth();
+  const { loginWithGoogle } = useAuth();
   const [error, setError] = useState<string>('');
   const navigate = useNavigate();
 
   const handleLogin = async (): Promise<void> => {
     try {
       setError('');
-      await login();
+      await loginWithGoogle();
       navigate('/dashboard');
     } catch (error) {
       setError(error instanceof Error ? error.message : 'An error occurred');

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -26,11 +26,14 @@ export const renderWithProviders = (
 ): RenderResult => {
   const defaultAuthValue: AuthContextProps = {
     currentUser: null,
+    user: null,
     isAuthReady: true,
     loading: false,
+    isLoading: false,
     error: null,
     login: mockLoginWithGoogle,
     loginWithGoogle: mockLoginWithGoogle,
+    signup: jest.fn(),
     logout: jest.fn(),
     clearError: jest.fn(),
     ...mockAuthValue

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,12 +1,4 @@
-import { UserCredential } from 'firebase/auth';
-import { User as SupabaseUser } from '@supabase/supabase-js';
-
-// Common types for auth context and components
-export interface User extends SupabaseUser {
-  uid: string;  // Ensure uid is available for Firebase compatibility
-}
-
-export type { Session } from '@supabase/supabase-js';
+import { User, UserCredential } from 'firebase/auth';
 
 export interface AuthError {
   code?: string;
@@ -15,13 +7,16 @@ export interface AuthError {
 
 export interface AuthContextType {
   currentUser: User | null;
+  user: User | null;
   loading: boolean;
-  authError: string | null;
+  isLoading: boolean;
+  isAuthReady: boolean;
+  error: string | null;
   login: (email: string, password: string) => Promise<UserCredential>;
   loginWithGoogle: () => Promise<void>;
   signup: (email: string, password: string) => Promise<UserCredential>;
   logout: () => Promise<void>;
-  setAuthError: (error: string | null) => void;
+  clearError: () => void;
 }
 
 export interface Student {


### PR DESCRIPTION
### Motivation

- Normalize the auth context API so UI consumers read consistent fields (`loading`, `isLoading`, `isAuthReady`, `error`, `user`).
- Provide the auth functions the UI expects (`loginWithGoogle`, `login`, `signup`, `logout`, `clearError`) and surface them from the context.
- Reuse the existing Firebase helpers for popup sign-in and sign-out and ensure error/loading state is managed around those operations.

### Description

- Expanded and exported `AuthContext` to satisfy `AuthContextType` in `src/types/auth.ts`, adding `user`, `loading`/`isLoading`, `isAuthReady`, `error`, `clearError` and the auth function signatures (`login`, `loginWithGoogle`, `signup`, `logout`).
- Implemented `loginWithGoogle` and `logout` by calling `firebaseService.signInWithGoogle()` and `firebaseService.signOut()` and wrapped those calls with a shared `runWithAuthState` helper to update `loading`/`error` state.
- Added email/password `login` and `signup` using `signInWithEmailAndPassword` and `createUserWithEmailAndPassword`, and normalized the provider value to include both `currentUser` and the `user` alias.
- Updated consumers and test utilities to match the new context shape, including changes in `src/components/Login.tsx`, `src/components/auth/LoginForm.tsx`, `src/pages/Curriculum.tsx`, and `src/test/testUtils.tsx`.

### Testing

- No automated tests were executed as part of this change.
- Updated `src/test/testUtils.tsx` mocks to match the new `AuthContext` shape so tests can run against the updated API.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530e48a5588326a2028c383cee8d3e)