### PR TITLE
Delegate Google sign-in to auth hook and unify LoginForm handling

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -1,4 +1,3 @@
-import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth';
 import React from 'react';
 import styled from 'styled-components';
 import { FcGoogle } from 'react-icons/fc';
@@ -16,12 +15,8 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
   error,
   onDismissError
 }): JSX.Element => {
-  const provider = new GoogleAuthProvider();
-  const auth = getAuth();
-
   const handleClick = async (): Promise<void> => {
     try {
-      await signInWithPopup(auth, provider);
       await handleGoogleLogin();
     } catch (err) {
       console.error('Google login error:', err);


### PR DESCRIPTION
### Motivation
- Centralize the Google sign-in flow so Firebase popup logic lives in one place rather than being invoked from the button component.
- Ensure consistent `loading`/`error`/`onDismissError` behavior across login UI by aligning `LoginForm` with the logic used in `src/pages/Login.tsx`.
- Prevent duplicated sign-in code and make the `GoogleLoginButton` a pure presentational control that calls a provided handler.

### Description
- Removed direct Firebase popup handling (imports and `signInWithPopup` call) from `src/components/GoogleLoginButton.tsx` so it now only invokes the provided `handleGoogleLogin` prop.
- Updated `src/components/auth/LoginForm.tsx` to consume `loginWithGoogle`, `loading`, `error`, and `clearError` from `useAuth()` and to add `localError`, `loading`, `handleDismissError`, and `handleGoogleLogin` to mirror `src/pages/Login.tsx` behavior.
- Wired `GoogleLoginButton` in `LoginForm` with `handleGoogleLogin`, `loading`, `error`, and `onDismissError` props and disabled the submit `Login` `Button` while loading.
- Preserved redirect semantics by using `location.state?.from?.pathname || '/dashboard'` after successful google/email login.

### Testing
- No automated tests were executed as part of this change.
- The project contains unit tests for the button at `src/components/GoogleLoginButton.test.tsx` which were not run during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531071214c8326974a5414b23d601e)