### PR TITLE
Fix Google login fallback and button handling

### DIFF
--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FcGoogle } from 'react-icons/fc';
+import { useAuth } from '../contexts/AuthContext';
 
 interface GoogleLoginButtonProps {
-  handleGoogleLogin: () => Promise<void>;
+  handleGoogleLogin?: () => Promise<void>;
   loading?: boolean;
   error?: string;
   onDismissError?: () => void;
@@ -15,9 +16,12 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({
   error,
   onDismissError
 }): JSX.Element => {
+  const { loginWithGoogle } = useAuth();
+  const triggerLogin = handleGoogleLogin ?? loginWithGoogle;
+
   const handleClick = async (): Promise<void> => {
     try {
-      await handleGoogleLogin();
+      await triggerLogin();
     } catch (err) {
       console.error('Google login error:', err);
     }

--- a/src/services/firebaseService.ts
+++ b/src/services/firebaseService.ts
@@ -1,14 +1,18 @@
 // frontend/src/services/firebaseService.ts
 // Using relative import until TS path mapping for @/config resolves in tooling
 import { auth } from '../config/firebase';
-import { 
-  signInWithPopup, 
+import {
+  signInWithPopup,
+  signInWithRedirect,
   GoogleAuthProvider,
   onAuthStateChanged,
   signOut,
   User
 } from 'firebase/auth';
 const googleProvider = new GoogleAuthProvider();
+googleProvider.setCustomParameters({
+  prompt: 'select_account'
+});
 
 export const firebaseService = {
   // Firebase Authentication
@@ -18,6 +22,14 @@ export const firebaseService = {
       return result.user;
     } catch (error) {
       console.error('Error signing in with Google:', error);
+      const firebaseError = error as { code?: string };
+      if (
+        firebaseError.code === 'auth/popup-blocked' ||
+        firebaseError.code === 'auth/internal-error'
+      ) {
+        await signInWithRedirect(auth, googleProvider);
+        return null;
+      }
       throw error;
     }
   },


### PR DESCRIPTION
### Motivation
- Resolve `auth/internal-error` and popup-blocked failures during Google sign-in by providing a robust fallback.
- Ensure the Google sign-in button uses the centralized AuthContext handler by default to keep auth flows consistent.

### Description
- Add `signInWithRedirect` fallback in `firebaseService.signInWithGoogle` for `auth/popup-blocked` and `auth/internal-error` cases and return `null` after redirect.
- Import and set `GoogleAuthProvider` custom parameters with `prompt: 'select_account'` to ensure account selection.
- Make `GoogleLoginButton` accept an optional `handleGoogleLogin` prop and default to `useAuth().loginWithGoogle` when no handler is provided.
- Update the button to call the resolved `triggerLogin` handler so the UI routes through the AuthContext by default.

### Testing
- No automated tests were executed as part of this change.
- Existing component unit tests (e.g. `GoogleLoginButton` tests) were not modified by this PR and should be run in CI to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530ddce0fc83268572b35c4c688a07)