### PR TITLE
Handle auth redirect resolution before marking auth ready

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { createUserWithEmailAndPassword, onAuthStateChanged, signInWithEmailAndPassword, User, UserCredential } from 'firebase/auth';
+import {
+  createUserWithEmailAndPassword,
+  getRedirectResult,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  User,
+  UserCredential
+} from 'firebase/auth';
 import { auth } from '../config/firebase';
 import { firebaseService } from '../services/firebaseService';
 import type { AuthContextType } from '../types/auth';
@@ -34,6 +41,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [isAuthReady, setIsAuthReady] = useState(false);
+  const [isRedirectResolved, setIsRedirectResolved] = useState(false);
+  const [isAuthStateResolved, setIsAuthStateResolved] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -41,20 +50,57 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       auth,
       (user) => {
         setCurrentUser(user);
-        setLoading(false);
-        setIsAuthReady(true);
         setError(null);
+        setIsAuthStateResolved(true);
       },
       (authError) => {
         console.error('Auth state change error:', authError);
         setError(authError instanceof Error ? authError.message : 'Failed to determine auth state');
-        setLoading(false);
-        setIsAuthReady(true);
+        setIsAuthStateResolved(true);
       }
     );
 
     return unsubscribe;
   }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const resolveRedirect = async () => {
+      try {
+        const result = await getRedirectResult(auth);
+        if (result?.user && isMounted) {
+          setCurrentUser(result.user);
+        }
+      } catch (redirectError) {
+        console.error('Redirect result error:', redirectError);
+        if (isMounted) {
+          setError(
+            redirectError instanceof Error
+              ? redirectError.message
+              : 'Failed to complete redirect sign-in'
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setIsRedirectResolved(true);
+        }
+      }
+    };
+
+    resolveRedirect();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isRedirectResolved && isAuthStateResolved) {
+      setLoading(false);
+      setIsAuthReady(true);
+    }
+  }, [isRedirectResolved, isAuthStateResolved]);
 
   const clearError = () => setError(null);
 


### PR DESCRIPTION
### Motivation
- Ensure redirect-based sign-in flows (e.g. Google redirect) are processed before the app treats auth as ready.
- Prevent `PrivateRoute` from redirecting to `/login` prematurely while redirect sign-in is resolving.
- Surface the redirect result user immediately so downstream UI can react without waiting on the auth state change alone.

### Description
- Added `getRedirectResult(auth)` handling in `AuthContext` and a `useEffect` to resolve the redirect flow and set `currentUser` when a result exists.
- Introduced `isRedirectResolved` and `isAuthStateResolved` flags and combined them to gate when `loading` is cleared and `isAuthReady` becomes `true`.
- Kept existing `onAuthStateChanged` behavior but now mark auth-state resolution via `isAuthStateResolved` instead of immediately toggling readiness.
- This gating ensures existing `PrivateRoute` logic that checks `isAuthReady` will wait for redirect completion before redirecting to `/login`.

### Testing
- No automated tests were executed for this change.
- Manual validation was not recorded as part of this PR run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531672cef48326a6cccd798f9b4d98)