### PR TITLE
Adjust Google login redirect handling

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -134,10 +134,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       'Failed to sign up'
     );
 
-  const loginWithGoogle = (): Promise<void> =>
-    runWithAuthState(async () => {
-      await firebaseService.signInWithGoogle();
-    }, 'Failed to sign in with Google');
+  const loginWithGoogle = (): Promise<User | null> =>
+    runWithAuthState(
+      async () => firebaseService.signInWithGoogle(),
+      'Failed to sign in with Google'
+    );
 
   const logout = (): Promise<void> =>
     runWithAuthState(async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -18,6 +18,7 @@ const Login: React.FC = () => {
   const location = useLocation();
   const [localError, setLocalError] = useState<string>('');
   const [loading, setLoading] = useState(false);
+  const isFinishingSignIn = authLoading && !isAuthReady;
 
   useEffect(() => {
     if (typeof clearError === 'function') {
@@ -43,9 +44,11 @@ const Login: React.FC = () => {
     try {
       setLocalError('');
       setLoading(true);
-      await loginWithGoogle();
-      const destination = location.state?.from?.pathname || '/dashboard';
-      navigate(destination, { replace: true });
+      const loginResult = await loginWithGoogle();
+      if (loginResult || currentUser) {
+        const destination = location.state?.from?.pathname || '/dashboard';
+        navigate(destination, { replace: true });
+      }
     } catch (err) {
       setLocalError(err instanceof Error ? err.message : 'Failed to sign in');
       console.error('Login error:', err);
@@ -58,6 +61,7 @@ const Login: React.FC = () => {
     return (
       <LoadingContainer>
         <LoadingSpinner />
+        {isFinishingSignIn && <LoadingMessage>Finishing sign-in…</LoadingMessage>}
       </LoadingContainer>
     );
   }
@@ -111,7 +115,14 @@ const LoadingContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
+  gap: 0.75rem;
   min-height: calc(100vh - 60px);
+`;
+
+const LoadingMessage = styled.p`
+  color: var(--text-secondary);
+  margin: 0;
 `;
 
 const LoginContainer = styled.div`

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -13,7 +13,7 @@ export interface AuthContextType {
   isAuthReady: boolean;
   error: string | null;
   login: (email: string, password: string) => Promise<UserCredential>;
-  loginWithGoogle: () => Promise<void>;
+  loginWithGoogle: () => Promise<User | null>;
   signup: (email: string, password: string) => Promise<UserCredential>;
   logout: () => Promise<void>;
   clearError: () => void;


### PR DESCRIPTION
### Motivation
- Prevent premature navigation when Google sign-in uses redirect and the redirect result is still being resolved.
- Let the auth state resolution (`currentUser`/`isAuthReady`) drive navigation when appropriate instead of always navigating immediately after starting sign-in.
- Surface a brief UI status so users know the app is completing a redirect-based sign-in.

### Description
- Change the `loginWithGoogle` contract to return the sign-in result by updating `AuthContext` to return `User | null` and update `src/types/auth.ts` to match the new signature (`loginWithGoogle: () => Promise<User | null>`).
- Update `src/pages/Login.tsx` `handleGoogleLogin` to `await loginWithGoogle()` and only call `navigate` when the returned `loginResult` or `currentUser` is available, avoiding navigation during redirect flows.
- Add an `isFinishingSignIn` flag (`authLoading && !isAuthReady`) and display a `Finishing sign-in…` message while redirect results are being resolved, and adjust the loading container layout and add a `LoadingMessage` styled component.

### Testing
- No automated tests were executed as part of this change.
- Local type changes were applied to `src/types/auth.ts` to keep TypeScript signatures consistent with the new return value for `loginWithGoogle`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69531768e29c8326957af83a7f287418)