### PR TITLE
Handle cancelled Google sign-in flows

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -104,6 +104,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const clearError = () => setError(null);
 
+  const isPopupCancelled = (authError: unknown): boolean => {
+    const firebaseError = authError as { code?: string };
+    return firebaseError.code === 'auth/popup-closed-by-user';
+  };
+
   const runWithAuthState = async <T,>(
     action: () => Promise<T>,
     fallbackMessage: string
@@ -113,6 +118,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     try {
       return await action();
     } catch (authError) {
+      if (isPopupCancelled(authError)) {
+        return null as T;
+      }
       const message =
         authError instanceof Error ? authError.message : fallbackMessage;
       setError(message);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -45,11 +45,18 @@ const Login: React.FC = () => {
       setLocalError('');
       setLoading(true);
       const loginResult = await loginWithGoogle();
+      if (!loginResult && !currentUser) {
+        return;
+      }
       if (loginResult || currentUser) {
         const destination = location.state?.from?.pathname || '/dashboard';
         navigate(destination, { replace: true });
       }
     } catch (err) {
+      const firebaseError = err as { code?: string };
+      if (firebaseError.code === 'auth/popup-closed-by-user') {
+        return;
+      }
       setLocalError(err instanceof Error ? err.message : 'Failed to sign in');
       console.error('Login error:', err);
     } finally {

--- a/src/services/firebaseService.ts
+++ b/src/services/firebaseService.ts
@@ -21,8 +21,11 @@ export const firebaseService = {
       const result = await signInWithPopup(auth, googleProvider);
       return result.user;
     } catch (error) {
-      console.error('Error signing in with Google:', error);
       const firebaseError = error as { code?: string };
+      if (firebaseError.code === 'auth/popup-closed-by-user') {
+        return null;
+      }
+      console.error('Error signing in with Google:', error);
       if (
         firebaseError.code === 'auth/popup-blocked' ||
         firebaseError.code === 'auth/internal-error'


### PR DESCRIPTION
### Motivation

- Prevent treating a user-cancelled Google popup as an application error and reduce noisy logs and error state updates.  
- Avoid showing an incorrect "Failed to sign in" message when the user intentionally closes the Google sign-in popup.  
- Preserve existing fallback behavior for popup-blocked or internal errors that require redirecting to `signInWithRedirect`.  

### Description

- Update `firebaseService.signInWithGoogle` to detect `error.code === 'auth/popup-closed-by-user'` and return `null` without logging or throwing.  
- Add `isPopupCancelled` helper in `AuthContext` and change `runWithAuthState` to skip setting `error` and rethrowing when the popup-cancel code is detected (it returns `null` instead).  
- Modify `Login.tsx` `handleGoogleLogin` to no-op and avoid navigation or showing `Failed to sign in` when `loginWithGoogle` returns `null` or an `auth/popup-closed-by-user` error is thrown.  

### Testing

- No automated tests were run for this change.  
- Changes were limited to error handling paths and do not alter successful sign-in or redirect fallback logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953238a6e888326a9d2e133d55bb375)