### PR TITLE
Enable React Router v7 future flags in main router

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,11 @@ import './styles/global.css';
 import './config/firebase';
 
 // Configure future flags for React Router v7
+const future = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true
+};
+
 const router = createBrowserRouter([
   {
     path: "/*",
@@ -25,9 +30,7 @@ const router = createBrowserRouter([
     ),
   }
 ], {
-  future: {
-    v7_relativeSplatPath: true
-  }
+  future
 });
 
 // Listen for auth service worker status events


### PR DESCRIPTION
### Motivation
- Keep React Router configuration consistent between `src/main.tsx`, `src/test/testUtils.tsx`, and `vite.config.js`.
- Opt into v7 features required by the codebase: `v7_startTransition` and `v7_relativeSplatPath`.
- Ensure router behavior in the browser matches test and build-time settings for routes and transition semantics.

### Description
- Add a shared `future` constant in `src/main.tsx` with `v7_startTransition: true` and `v7_relativeSplatPath: true`.
- Pass the `future` object into `createBrowserRouter` options instead of the previous inline configuration.
- No other runtime changes were made; the `RouterProvider` usage remains unchanged.

### Testing
- No automated tests were run as part of this change.
- Manual local build and file verification were used to confirm the code change applied correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532b7db2a883268bf181cec0328040)