### PR TITLE
Add hosting COOP/COEP headers for Firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,21 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "/**",
+        "headers": [
+          {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          },
+          {
+            "key": "Cross-Origin-Embedder-Policy",
+            "value": "credentialless"
+          }
+        ]
+      }
     ]
   },
   "remoteconfig": {


### PR DESCRIPTION
### Motivation
- Mirror the dev server's COOP/COEP headers in production to prevent COOP warnings for popup auth flows.
- Ensure `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` are explicitly set for all hosting responses.
- Align Firebase Hosting behavior with `vite.config.js` to avoid differences between local dev and deployed site.

### Description
- Add a `headers` entry under `hosting` in `firebase.json` with `source` set to `/**`.
- Set `Cross-Origin-Opener-Policy` to `same-origin-allow-popups` and `Cross-Origin-Embedder-Policy` to `credentialless` for all paths.
- Modify only `firebase.json` to include the new headers and leave other configuration unchanged.

### Testing
- Confirmed matching header values in `vite.config.js` using a search for the COOP/COEP keys, which succeeded.
- Attempted `firebase deploy --only hosting`, but the command failed because the Firebase CLI is not available in the environment.
- No other automated tests were run against the deployed hosting configuration due to the CLI limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532c1458348326872f3416e088083b)