### PR TITLE
Fix Google login redirect state

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -143,10 +143,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     );
 
   const loginWithGoogle = (): Promise<User | null> =>
-    runWithAuthState(
-      async () => firebaseService.signInWithGoogle(),
-      'Failed to sign in with Google'
-    );
+    runWithAuthState(async () => {
+      const user = await firebaseService.signInWithGoogle();
+      if (user) {
+        setCurrentUser(user);
+      }
+      return user;
+    }, 'Failed to sign in with Google');
 
   const logout = (): Promise<void> =>
     runWithAuthState(async () => {


### PR DESCRIPTION
### Motivation
- Google sign-in was completing but the app was redirecting back to the login page instead of the dashboard.
- The cause appears to be that auth state updates from `onAuthStateChanged` can lag after a popup sign-in, causing page routing to think the user is unauthenticated.
- Ensure the app sets the authenticated user immediately after a successful Google sign-in to avoid navigation bounce.

### Description
- Update `loginWithGoogle` in `src/contexts/AuthContext.tsx` to call `firebaseService.signInWithGoogle()` and, when a `user` is returned, call `setCurrentUser(user)` before returning.
- Keep the `runWithAuthState` wrapper for consistent loading/error handling and the existing error-path behavior.
- No other files were modified; the change ensures the AuthContext reflects the signed-in user immediately after `signInWithGoogle`.

### Testing
- No automated tests were run as part of this change.
- Recommend running the project test suite with `npm test` or `yarn test` in CI or locally to validate existing unit/integration tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532d4109c8832693cf73788211c85a)