### PR TITLE
Respect auth `loading` state in PrivateRoute

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -21,11 +21,11 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }): JSX.Element => {
-  const { currentUser, isAuthReady } = useAuth();
+  const { currentUser, isAuthReady, loading } = useAuth();
   const location = useLocation();
 
   // Show loading spinner while auth state is being determined
-  if (!isAuthReady) {
+  if (loading || !isAuthReady) {
     return (
       <LoadingContainer>
         <LoadingSpinner />
@@ -34,7 +34,7 @@ const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }): JSX.Element =>
   }
 
   // If not authenticated, redirect to login with current location
-  if (!currentUser && isAuthReady) {
+  if (!loading && currentUser === null) {
     // Only redirect if we're not already on the login page
     if (location.pathname !== '/login') {
       return (


### PR DESCRIPTION
### Motivation
- Avoid redirecting to the login page while the authentication hook is still loading. 
- Ensure a loading spinner is shown whenever auth readiness or `loading` indicates auth is in progress. 
- Only perform the redirect to `/login` when `loading === false` and `currentUser === null`. 
- Preserve the existing `Navigate` `state` shape so the login page can return the user to the original target.

### Description
- Destructure `loading` from `useAuth()` in `src/components/PrivateRoute.tsx`.
- Show the loading spinner when `loading || !isAuthReady` by returning the existing `LoadingContainer` with `LoadingSpinner`.
- Change the redirect condition to `if (!loading && currentUser === null)` and keep `state={{ from: location, error: "Please sign in to access this page" }}` on `Navigate`.
- Leave rendering of protected `children` unchanged when authentication is satisfied.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535029f240832692f05cb49be255c7)