### PR TITLE
Configure Vite HMR to use tailnet WSS and add tailnet to CSP

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -50,6 +50,7 @@ const csp = `
     http://0.0.0.0:5173 ws://0.0.0.0:5173
     http://100.86.7.87:5173 ws://100.86.7.87:5173
     http://*.${TAILNET_DOMAIN}:5173 ws://*.${TAILNET_DOMAIN}:5173
+    https://*.${TAILNET_DOMAIN} wss://*.${TAILNET_DOMAIN}
     https://*.firebaseio.com https://*.firebase.com wss://*.firebaseio.com
     https://*.googleapis.com https://firestore.googleapis.com wss://firestore.googleapis.com;
   frame-src 'self'
@@ -174,20 +175,13 @@ export default defineConfig({
     },
 
     // HMR: let it auto-detect unless you explicitly set VITE_DEV_HOST
-    hmr: DEV_HOST
-      ? {
-          protocol: "ws",
-          host: DEV_HOST,
-          port: 5173,
-          clientPort: 5173,
-          timeout: 120000,
-        }
-      : {
-          protocol: "ws",
-          port: 5173,
-          clientPort: 5173,
-          timeout: 120000,
-        },
+    hmr: {
+      protocol: "wss",
+      host: "evopimp-stylistic-q704.tail78d61.ts.net",
+      port: 443,
+      clientPort: 443,
+      timeout: 120000,
+    },
 
     watch: {
       usePolling: true,


### PR DESCRIPTION
### Motivation
- Allow the dev server and HMR client to communicate over secure WebSockets through the tailnet FQDN to avoid mixed-content or host-blocking issues.
- Permit HTTPS and WSS connections to tailnet hosts in the Content Security Policy so the browser can connect to the remote dev host.
- Preserve existing Firebase/Google endpoints in the CSP so those services remain allowed.

### Description
- Updated `vite.config.js` to add `https://*.${TAILNET_DOMAIN}` and `wss://*.${TAILNET_DOMAIN}` to the `connect-src` section of the `csp` string.
- Replaced the conditional `hmr` auto-detect block with a fixed `server.hmr` configuration using `protocol: "wss"`, `host: "evopimp-stylistic-q704.tail78d61.ts.net"`, `port: 443`, and `clientPort: 443`.
- Kept the existing Firebase/Google CSP entries and other server settings unchanged.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695350da487c832694936462d99c22ca)