### PR TITLE
Allow localhost in Vite allowed hosts

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -123,6 +123,7 @@ export default defineConfig({
     // ✅ Fix for: "Blocked request. This host (...) is not allowed."
     // Allow your MagicDNS host + any *.tail78d61.ts.net hosts
     allowedHosts: [
+      "localhost",
       "evopimp-stylistic-q704",
       "100.86.7.87",
       `.${TAILNET_DOMAIN}`,


### PR DESCRIPTION
### Motivation
- Prevent dev-server host blocking when accessing the app via `localhost` during local development.
- Ensure local workflows (browsing at `http://localhost:5173`) and tools that rely on `localhost` are permitted by Vite.

### Description
- Updated `vite.config.js` to add `"localhost"` to the `server.allowedHosts` array.
- Change targets the Vite dev server configuration under the `server` section to include local host access.

### Testing
- No automated tests were run for this change.
- No build or CI checks were executed as part of this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953529bc5a88326807c401202e4887b)