### PR TITLE
Fix auth redirect flow and route guards

### DIFF
--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -21,33 +21,31 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }): JSX.Element => {
-  const { currentUser, isAuthReady, loading } = useAuth();
+  const { user, loading } = useAuth();
   const location = useLocation();
 
   // Show loading spinner while auth state is being determined
-  if (loading || !isAuthReady) {
+  if (loading) {
     return (
       <LoadingContainer>
         <LoadingSpinner />
+        <span>Loading…</span>
       </LoadingContainer>
     );
   }
 
   // If not authenticated, redirect to login with current location
-  if (!loading && currentUser === null) {
-    // Only redirect if we're not already on the login page
-    if (location.pathname !== '/login') {
-      return (
-        <Navigate 
-          to="/login" 
-          state={{ 
-            from: location,
-            error: "Please sign in to access this page" 
-          }} 
-          replace 
-        />
-      );
-    }
+  if (!user) {
+    return (
+      <Navigate 
+        to="/login" 
+        state={{ 
+          from: location,
+          error: "Please sign in to access this page" 
+        }} 
+        replace 
+      />
+    );
   }
 
   // If authenticated, render the protected route

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -4,7 +4,7 @@
 // Created: 2025-09-07
 
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import { browserLocalPersistence, getAuth, setPersistence } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
 // Validate required Firebase config (warn only in dev so UI still mounts)
@@ -41,6 +41,9 @@ export const firebaseConfig = {
 // Ensure single app instance
 export const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+setPersistence(auth, browserLocalPersistence).catch((error) => {
+  console.error('[firebase] Failed to set auth persistence:', error);
+});
 export const firestore = getFirestore(app);
 
 // Default export kept for backward compatibility (legacy imports)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import {
   createUserWithEmailAndPassword,
   getRedirectResult,
@@ -41,86 +41,62 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [isAuthReady, setIsAuthReady] = useState(false);
-  const [isRedirectResolved, setIsRedirectResolved] = useState(false);
-  const [isAuthStateResolved, setIsAuthStateResolved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const redirectHandledRef = useRef(false);
+  const authResolvedRef = useRef(false);
 
   useEffect(() => {
+    console.log('Auth init start');
     const unsubscribe = onAuthStateChanged(
       auth,
       (user) => {
+        console.log('onAuthStateChanged user=', user);
         setCurrentUser(user);
         setError(null);
-        setIsAuthStateResolved(true);
+        if (!authResolvedRef.current) {
+          authResolvedRef.current = true;
+          setLoading(false);
+          setIsAuthReady(true);
+        }
       },
       (authError) => {
         console.error('Auth state change error:', authError);
         setError(authError instanceof Error ? authError.message : 'Failed to determine auth state');
-        setIsAuthStateResolved(true);
+        if (!authResolvedRef.current) {
+          authResolvedRef.current = true;
+          setLoading(false);
+          setIsAuthReady(true);
+        }
       }
-    );
-
-    const authStateTimeout = window.setTimeout(() => {
-      setIsAuthStateResolved(true);
-    }, 7000);
+    };
 
     return () => {
-      window.clearTimeout(authStateTimeout);
       unsubscribe();
     };
   }, []);
 
   useEffect(() => {
-    let isMounted = true;
+    if (redirectHandledRef.current) {
+      return;
+    }
+    redirectHandledRef.current = true;
 
     const resolveRedirect = async () => {
       try {
-        const result = await Promise.race([
-          getRedirectResult(auth),
-          new Promise<null>((resolve) => window.setTimeout(() => resolve(null), 7000))
-        ]);
-        if (result?.user && isMounted) {
-          setCurrentUser(result.user);
-          const redirectTarget = sessionStorage.getItem('postLoginRedirect');
-          if (redirectTarget) {
-            sessionStorage.removeItem('postLoginRedirect');
-            if (
-              `${window.location.pathname}${window.location.search}${window.location.hash}` !==
-              redirectTarget
-            ) {
-              window.location.replace(redirectTarget);
-            }
-          }
-        }
+        const result = await getRedirectResult(auth);
+        console.log('getRedirectResult result=', result);
       } catch (redirectError) {
-        console.error('Redirect result error:', redirectError);
-        if (isMounted) {
-          setError(
-            redirectError instanceof Error
-              ? redirectError.message
-              : 'Failed to complete redirect sign-in'
-          );
-        }
-      } finally {
-        if (isMounted) {
-          setIsRedirectResolved(true);
-        }
+        console.error('getRedirectResult error:', redirectError);
+        setError(
+          redirectError instanceof Error
+            ? redirectError.message
+            : 'Failed to complete redirect sign-in'
+        );
       }
     };
 
     resolveRedirect();
-
-    return () => {
-      isMounted = false;
-    };
   }, []);
-
-  useEffect(() => {
-    if (isRedirectResolved && isAuthStateResolved) {
-      setLoading(false);
-      setIsAuthReady(true);
-    }
-  }, [isRedirectResolved, isAuthStateResolved]);
 
   const clearError = () => setError(null);
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,12 @@ const Login: React.FC = () => {
 
   useEffect(() => {
     if (!authLoading && currentUser) {
-      const destination = location.state?.from?.pathname || '/dashboard';
+      const storedRedirect = sessionStorage.getItem('postLoginRedirect');
+      const destination = storedRedirect || location.state?.from?.pathname || '/dashboard';
+      if (storedRedirect) {
+        sessionStorage.removeItem('postLoginRedirect');
+      }
+      console.log('Navigating to', destination);
       navigate(destination, { replace: true });
     }
   }, [authLoading, currentUser, location.state?.from?.pathname, navigate]);
@@ -44,12 +49,19 @@ const Login: React.FC = () => {
     try {
       setLocalError('');
       setLoading(true);
+      const redirectTarget = location.state?.from?.pathname || '/dashboard';
+      sessionStorage.setItem('postLoginRedirect', redirectTarget);
       const loginResult = await loginWithGoogle();
       if (!loginResult && !currentUser) {
         return;
       }
       if (loginResult || currentUser) {
-        const destination = location.state?.from?.pathname || '/dashboard';
+        const storedRedirect = sessionStorage.getItem('postLoginRedirect');
+        const destination = storedRedirect || location.state?.from?.pathname || '/dashboard';
+        if (storedRedirect) {
+          sessionStorage.removeItem('postLoginRedirect');
+        }
+        console.log('Navigating to', destination);
         navigate(destination, { replace: true });
       }
     } catch (err) {

--- a/src/services/firebaseService.ts
+++ b/src/services/firebaseService.ts
@@ -2,7 +2,6 @@
 // Using relative import until TS path mapping for @/config resolves in tooling
 import { auth } from '../config/firebase';
 import {
-  signInWithPopup,
   signInWithRedirect,
   GoogleAuthProvider,
   onAuthStateChanged,
@@ -18,34 +17,10 @@ export const firebaseService = {
   // Firebase Authentication
   signInWithGoogle: async () => {
     try {
-      const isLocalhost = ['localhost', '127.0.0.1'].includes(window.location.hostname);
-      if (!isLocalhost) {
-        sessionStorage.setItem(
-          'postLoginRedirect',
-          `${window.location.pathname}${window.location.search}${window.location.hash}`
-        );
-        await signInWithRedirect(auth, googleProvider);
-        return null;
-      }
-      const result = await signInWithPopup(auth, googleProvider);
-      return result.user;
+      await signInWithRedirect(auth, googleProvider);
+      return null;
     } catch (error) {
-      const firebaseError = error as { code?: string };
-      if (firebaseError.code === 'auth/popup-closed-by-user') {
-        return null;
-      }
       console.error('Error signing in with Google:', error);
-      if (
-        firebaseError.code === 'auth/popup-blocked' ||
-        firebaseError.code === 'auth/internal-error'
-      ) {
-        sessionStorage.setItem(
-          'postLoginRedirect',
-          `${window.location.pathname}${window.location.search}${window.location.hash}`
-        );
-        await signInWithRedirect(auth, googleProvider);
-        return null;
-      }
       throw error;
     }
   },


### PR DESCRIPTION
### Motivation
- Stop the Google redirect loop by making redirect-result processing deterministic and only run once.
- Make protected routes and auth pages wait for auth initialization so they don't redirect prematurely.
- Preserve and restore the intended post-login route so users land where they started after redirect sign-in.
- Ensure auth persistence is durable across sessions by using browser local persistence.

### Description
- Set Firebase auth persistence with `setPersistence(auth, browserLocalPersistence)` in `src/config/firebase.ts` and log failures.
- Simplified `signInWithGoogle` in `src/services/firebaseService.ts` to always use `signInWithRedirect` (redirect-only flow) and removed popup fallbacks.
- Reworked `AuthProvider` in `src/contexts/AuthContext.tsx` to use refs for one-time checks, subscribe to `onAuthStateChanged`, call `getRedirectResult(auth)` exactly once, and only clear `loading` after the first auth state resolution, with console logs `Auth init start`, `onAuthStateChanged user=…`, and `getRedirectResult result=…`.
- Updated route guarding and login navigation: `src/components/PrivateRoute.tsx` now shows a centered loading state while `loading` is true and returns a `Navigate` to `/login` only when `user` is falsy; `src/pages/Login.tsx` now persists the intended path to `sessionStorage.postLoginRedirect`, restores it after sign-in, removes the stored item, and logs `Navigating to …`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535abc0ba48326a1792c3ea94174fc)