### PR TITLE
Fix syntax error in AuthContext onAuthStateChanged call

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -68,7 +68,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setIsAuthReady(true);
         }
       }
-    };
+    );
 
     return () => {
       unsubscribe();


### PR DESCRIPTION
### Motivation
- The `AuthContext` file caused a syntax error (`Unexpected token`) due to an incorrectly closed `onAuthStateChanged` call. 
- This prevented the React/TypeScript codebase from parsing and likely blocked builds or dev server startup.

### Description
- Fixed the call site in `src/contexts/AuthContext.tsx` by replacing the stray `};` with `);` to properly close the `onAuthStateChanged` invocation. 
- The change is a single-line syntactic fix and preserves the existing auth state handling and `unsubscribe` behavior. 
- The file was staged and committed with the message `Fix auth state change handler syntax`.

### Testing
- No automated tests were run on this change. 
- No CI/build was executed as part of this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535e2a47ac8326942730a4d77ead95)