### PR TITLE
Harden auth persistence initialization

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -67,48 +67,42 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
       try {
         await authInit;
-        if (!isMounted) return;
-        if (isDev) {
-          console.debug('[AuthProvider] before onAuthStateChanged subscribe');
-        }
-        unsubscribe = onAuthStateChanged(
-          auth,
-          (user) => {
-            if (isDev) {
-              console.debug('[AuthProvider] onAuthStateChanged', {
-                userUid: user?.uid ?? null,
-                currentUserUid: auth.currentUser?.uid ?? null
-              });
-            }
-            setCurrentUser(user);
-            setError(null);
-            if (!hasResolved) {
-              hasResolved = true;
-              setLoading(false);
-              setIsAuthReady(true);
-            }
-          },
-          (authError) => {
-            console.error('Auth state change error:', authError);
-            setError(authError instanceof Error ? authError.message : 'Failed to determine auth state');
-            if (!hasResolved) {
-              hasResolved = true;
-              setLoading(false);
-              setIsAuthReady(true);
-            }
-          }
-        );
-        if (isDev) {
-          console.debug('[AuthProvider] after onAuthStateChanged subscribe');
-        }
       } catch (authError) {
-        console.error('Auth state listener registration failed:', authError);
-        setError(
-          authError instanceof Error ? authError.message : 'Failed to initialize auth listener'
-        );
-        setLoading(false);
-        setIsAuthReady(true);
+        console.warn('[AuthProvider] authInit failed (continuing):', authError);
       }
+
+      if (!isMounted) return;
+      if (isDev) {
+        console.debug('[AuthProvider] subscribing onAuthStateChanged');
+      }
+      unsubscribe = onAuthStateChanged(
+        auth,
+        (user) => {
+          if (isDev) {
+            console.debug('[AuthProvider] onAuthStateChanged', {
+              userUid: user?.uid ?? null,
+              currentUserUid: auth.currentUser?.uid ?? null,
+              persistenceManager: (auth as { persistenceManager?: unknown }).persistenceManager
+            });
+          }
+          setCurrentUser(user);
+          setError(null);
+          if (!hasResolved) {
+            hasResolved = true;
+            setLoading(false);
+            setIsAuthReady(true);
+          }
+        },
+        (authError) => {
+          console.error('Auth state change error:', authError);
+          setError(authError instanceof Error ? authError.message : 'Failed to determine auth state');
+          if (!hasResolved) {
+            hasResolved = true;
+            setLoading(false);
+            setIsAuthReady(true);
+          }
+        }
+      );
     };
 
     initAuth();


### PR DESCRIPTION
### Motivation

- Fix a hang where `authInit` could remain pending if the browser blocks storage, preventing `onAuthStateChanged` from subscribing and leaving `isAuthReady` false.
- Ensure the app proceeds to subscribe to auth state changes even when persistence setup fails or is slow.
- Provide clearer DEV logging to show which persistence path was used and to confirm the auth listener is firing.
- Preserve production behavior while avoiding startup failure due to persistence issues.

### Description

- Import `browserSessionPersistence` and add a `withTimeout` helper to race `setPersistence` calls against a 1000ms timeout.
- Replace the previous `authInit` with an async IIFE that tries local persistence first, falls back to session persistence on timeout/error, logs outcomes in DEV, and never leaves the promise pending.
- Update `AuthProvider` to always subscribe to `onAuthStateChanged` after awaiting `authInit`, add a DEV log `"[AuthProvider] subscribing onAuthStateChanged"`, and include `persistenceManager` info in the listener log.
- Ensure `isAuthReady` is set the first time the `onAuthStateChanged` callback fires and that persistence setup failures are caught and do not block the listener.

### Testing

- Ran `timeout 5s npm run dev -- --host 127.0.0.1 --port 5173` to exercise startup, which failed due to a missing `mkcert` dependency referenced by `scripts/generate-certs.js` (failure unrelated to auth changes).
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69542d05d57883269290aa9dd6d70ec7)