### PR TITLE
Fix Firestore permissions, enforce profile writes, and add runtime logging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,13 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /parents/{uid} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
     match /students/{studentId} {
-      allow read, write: if request.auth != null && 
+      allow create: if request.auth != null &&
+        request.resource.data.parentId == request.auth.uid;
+      allow read, update: if request.auth != null &&
         request.auth.uid == resource.data.parentId;
     }
     match /assessments/{assessmentId} {

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -105,6 +105,8 @@ export const authInit = (async () => {
 })();
 export const firestore = getFirestore(app);
 
+console.info('[firebase] projectId', firebaseConfig.projectId ?? 'unknown');
+
 if (import.meta.env.DEV) {
   console.debug('[firebase] app name', app.name);
   console.debug('[firebase] auth instance', auth.app.name);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -157,6 +157,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     resolveRedirect();
   }, []);
 
+  useEffect(() => {
+    console.info('[AuthProvider] active auth uid', currentUser?.uid ?? null);
+  }, [currentUser]);
+
   const clearError = () => setError(null);
 
   const isPopupCancelled = (authError: unknown): boolean => {

--- a/src/pages/profile/ParentProfile/CreateStudent.tsx
+++ b/src/pages/profile/ParentProfile/CreateStudent.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '../../../contexts/AuthContext';
 interface NewStudent {
   name: string;
   grade: string;
-  parentId: string;
   hasTakenAssessment: boolean;
 }
 
@@ -41,7 +40,6 @@ const CreateStudent: React.FC = () => {
       const newStudent: NewStudent = { 
         name: studentName.trim(), 
         grade: grade.trim(), 
-        parentId: currentUser.uid,
         hasTakenAssessment: false
       };
 

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -36,12 +36,16 @@ export const createParentProfile = async (parentData: Partial<Parent>): Promise<
   try {
     if (!parentData.uid) throw new Error('User ID is required');
     
+    const now = new Date().toISOString();
     const parentRef = doc(firestore, 'parents', parentData.uid);
     await setDoc(parentRef, {
-      ...parentData,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      students: []
+      uid: parentData.uid,
+      email: parentData.email ?? '',
+      displayName: parentData.displayName ?? '',
+      students: [],
+      createdAt: now,
+      updatedAt: now,
+      ...(parentData.phone ? { phone: parentData.phone } : {})
     });
     
     console.log('✅ Parent profile created successfully:', parentData.uid);
@@ -159,24 +163,25 @@ export const getStudentsByIds = async (ids: string[]): Promise<Student[]> => {
 export const addStudentProfile = async (parentId: string, studentData: {
   name: string;
   grade: string;
-  parentId: string;
   hasTakenAssessment: boolean;
 }) => {
   try {
     console.log('📝 Adding student profile for parent:', parentId);
+    const now = new Date().toISOString();
     
     // Add the student to the students collection
     const studentRef = await addDoc(collection(firestore, 'students'), {
       ...studentData,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
+      parentId,
+      createdAt: now,
+      updatedAt: now
     });
 
     // Update the parent's students array
     const parentRef = doc(firestore, 'parents', parentId);
     await updateDoc(parentRef, {
       students: arrayUnion(studentRef.id),
-      updatedAt: new Date().toISOString()
+      updatedAt: now
     });
 
     invalidateParentCache(parentId);


### PR DESCRIPTION
### Motivation
- Fix Firestore permission errors when reading `parents/{uid}` by enforcing owner-only access for parent documents.
- Ensure student documents are created and accessed only by their authenticated parent to prevent unauthorized access.
- Make parent and student writes deterministic (doc id == auth uid for parents and explicit `parentId` for students) to match security rules.
- Add runtime logging to help diagnose which Firebase project and auth UID are active at runtime.

### Description
- Updated `firestore.rules` to add `match /parents/{uid}` allowing read/write only when `request.auth.uid == uid`, and split `students` rules so `create` requires `request.resource.data.parentId == request.auth.uid` while `read`/`update` require ownership via `resource.data.parentId`.
- Modified `createParentProfile` in `src/services/profileService.ts` to write a parent doc with id == `uid` and explicit fields `uid`, `email`, `displayName`, `students`, `createdAt`, `updatedAt`, plus optional `phone`.
- Updated `addStudentProfile` to write `parentId` into the student doc, use a shared `now` timestamp, and update `parents/{uid}.students` with `arrayUnion(studentId)` while invalidating parent cache; adjusted the `NewStudent` type and callsite to drop the redundant `parentId` field.
- Added console logging for the Firebase `projectId` in `src/config/firebase.ts` and active auth UID in `src/contexts/AuthContext.tsx` to aid runtime debugging.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e508015483269f02e9eba62da5a4)