### PR TITLE
Update docs: switch backend direction to Node/Express + Cloud Run and add assessment roadmap

### DIFF
--- a/Assessment_Roadmap.md
+++ b/Assessment_Roadmap.md
@@ -1,0 +1,192 @@
+# Assessment Roadmap
+Next Steps: Cloud Run Node/Express Backend + Vertex AI for Learning Style Assessment
+
+This file is the “tomorrow plan” to connect the student assessment chat UI to a secure backend, call Vertex AI, and persist results into Firestore.
+
+---
+
+## 1) GCP Setup Checklist (Console work)
+
+### 1.1 Confirm project + region
+- Pick a region for Vertex AI and Cloud Run (common: us-central1).
+- Write these down:
+  - GOOGLE_CLOUD_PROJECT = <your-project-id>
+  - VERTEX_REGION = us-central1
+
+### 1.2 Enable required APIs
+Enable:
+- Vertex AI API
+- Cloud Run API
+- Artifact Registry API
+- Secret Manager API
+
+### 1.3 Create a Cloud Run service account
+Example:
+- geaux-academy-api-sa
+
+Grant roles:
+- Vertex AI User (or least privilege equivalent)
+- Firestore access as needed (Cloud Datastore User is common)
+- Secret Manager Secret Accessor (if using secrets)
+
+### 1.4 Decide Vertex AI model
+Pick a Gemini model available in Vertex AI.
+Record:
+- VERTEX_MODEL = <model-name-identifier>
+
+---
+
+## 2) Repo Changes (Code work)
+
+### 2.1 Create backend folder
+Add:
+- /server/package.json
+- /server/src/index.ts (Express app)
+- /server/src/middleware/auth.ts (Firebase token verification)
+- /server/src/routes/learningStyle.ts
+- /server/src/services/vertex.ts
+- /server/src/services/firestore.ts (optional helper)
+- /server/Dockerfile for Cloud Run
+
+### 2.2 Auth middleware
+Goal:
+- Require Authorization: Bearer <Firebase ID token>
+- Verify with Firebase Admin SDK
+- Set req.user = { uid, email }
+
+### 2.3 Ownership enforcement
+Before any student write:
+- Load students/{studentId}
+- Assert: student.parentId === req.user.uid
+- If not, return 403
+
+---
+
+## 3) API Contract
+
+### 3.1 Endpoint
+POST /api/learning-style/assess
+
+Body:
+{
+  "studentId": "string",
+  "messages": [{ "role": "user"|"assistant", "content": "string" }]
+}
+
+Response:
+{
+  "learningStyle": "Visual|Auditory|Reading/Writing|Kinesthetic|Mixed",
+  "confidence": 0.0-1.0,
+  "rationale": "string",
+  "recommendations": ["string"]
+}
+
+### 3.2 Firestore writes
+Update students/{studentId}:
+- learningStyle
+- assessmentResults: { confidence, rationale, recommendations }
+- hasTakenAssessment = true
+- assessmentStatus = "completed"
+- updatedAt
+
+Optional:
+Create assessments/{assessmentId}:
+- studentId
+- parentId
+- messages
+- result
+- model
+- createdAt
+
+---
+
+## 4) Vertex AI Prompting Strategy
+
+### 4.1 System instruction
+- Tell the model it must return ONLY valid JSON.
+- Provide a strict JSON schema.
+- Tell it to choose from the allowed enum list.
+- Keep rationale short and parent-friendly.
+
+### 4.2 Validation
+- Parse JSON
+- Validate keys and types
+- Clamp confidence to 0..1
+- If invalid, return a safe error and do NOT write to Firestore.
+
+---
+
+## 5) Frontend Wiring
+
+### 5.1 learningStyleService.ts
+- Get Firebase ID token: auth.currentUser.getIdToken()
+- Call fetch('/api/learning-style/assess', { headers: Authorization Bearer ... })
+
+### 5.2 LearningStyleChat integration
+- When user completes enough messages (or hits “Finish Assessment”), submit transcript to backend.
+- Show a “Generating results” state.
+- On success:
+  - Update UI to show learningStyle + recommendations
+  - StudentDashboard should detect hasTakenAssessment and stop showing the chat by default.
+
+### 5.3 Parent Dashboard display
+- When parent loads profile, show student cards:
+  - Assessment: Completed/Pending
+  - Learning Style (if available)
+
+---
+
+## 6) Cloud Run Deploy Steps
+
+### 6.1 Local smoke test
+- Run server locally
+- Verify:
+  - missing token returns 401
+  - wrong parentId returns 403
+  - correct owner returns 200 and writes to Firestore
+
+### 6.2 Deploy
+- Build container from /server
+- Deploy to Cloud Run
+- Set environment variables:
+  - GOOGLE_CLOUD_PROJECT
+  - VERTEX_REGION
+  - VERTEX_MODEL
+  - FIREBASE_PROJECT_ID
+- Attach service account:
+  - geaux-academy-api-sa
+
+### 6.3 Update frontend config
+- In production, point /api calls to Cloud Run URL (or use same-domain routing if behind a gateway).
+
+---
+
+## 7) Smoke Tests and Troubleshooting Notes
+
+### Smoke tests
+- Create student from Parent Dashboard.
+- Complete assessment to verify:
+  - students/{studentId}.learningStyle set
+  - students/{studentId}.assessmentStatus = completed
+  - assessments/{assessmentId} created (if enabled)
+
+### “Missing or insufficient permissions”
+- Confirm Firestore rules include parents and students access patterns.
+- Confirm students document includes parentId.
+- Confirm request.auth.uid matches.
+
+### Token verification fails
+- Ensure Firebase Admin is initialized with correct project.
+- Ensure frontend is sending Authorization header.
+
+### Vertex calls fail
+- Confirm service account has Vertex AI permissions.
+- Confirm Vertex API is enabled.
+- Confirm region matches the model availability.
+
+---
+
+## Tomorrow’s “first 3 wins”
+1) Create /server, verify Firebase token middleware works.
+2) Implement /api/learning-style/assess with ownership checks and mocked response first.
+3) Swap mock for Vertex call and write results to Firestore.

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -2,119 +2,221 @@
 
 ## Architecture Overview
 
+Geaux Academy is a parent-led, student-focused learning platform:
+- Parents create and manage Student Profiles.
+- Students complete a Learning Style Assessment via chat.
+- The platform stores learning style + recommendations in Firestore.
+- Next: a curriculum generation pipeline (CrewAI) produces grade-appropriate curriculum that parents approve.
+- Progress tracking feeds back into parent insights and interventions.
+
 ### Frontend
 - React 18+ with TypeScript
 - Vite for build tooling
-- Firebase SDK for auth/storage
-- Context API + Redux for state management
+- Firebase SDK for Authentication
+- Context API (and optionally Redux) for state management
 - Styled Components & CSS Modules
 
-### Backend
-- Python FastAPI backend
-- Firebase Authentication
-- Firestore Database
-- OpenAI integration for chat
+### Backend (Current Direction)
+- Node.js + Express API
+- Deployed to Google Cloud Run
+- Firebase Admin SDK for verifying Firebase ID tokens
+- Firestore for data persistence
+- Vertex AI (Gemini on Vertex) for Learning Style Assessment inference
+- Optional future services:
+  - CrewAI pipeline service for curriculum generation and validation
+  - Background job runner (Cloud Tasks / PubSub) for async workloads
 
-## Development Roadmap
+---
 
-### Phase 1: Foundation (Week 1-2)
-- [x] Project setup and configuration
-- [x] Basic authentication flow
-- [ ] Core UI components
-  - [ ] Navigation
-  - [ ] Layout system
-  - [ ] Theme implementation
-- [ ] Basic Firebase integration
-- [ ] Test environment setup
+## Current Status
 
-### Phase 2: Core Features (Week 3-4)
-- [ ] Learning Style Assessment
-  - [ ] Chat interface implementation
-  - [ ] OpenAI integration
-  - [ ] Response analysis system
-  - [ ] Results storage and retrieval
-- [ ] User Profile System
-  - [ ] Profile creation/editing
-  - [ ] Learning style data integration
-  - [ ] Progress tracking
+### Working
+- ✅ Firebase Auth (email/password) login works
+- ✅ Parent Dashboard loads for authenticated users
+- ✅ Parent can create a student (Firestore permissions resolved)
+- ✅ Student Dashboard loads and begins the assessment chat UI
 
-### Phase 3: Learning Experience (Week 5-6)
-- [ ] Content Management
-  - [ ] Learning material organization
-  - [ ] Content adaptation based on VARK
-  - [ ] Resource recommendation engine
-- [ ] Progress Tracking
-  - [ ] Analytics dashboard
-  - [ ] Performance metrics
-  - [ ] Learning path visualization
+### In Progress
+- ⏳ Tie assessment chat to backend endpoint
+- ⏳ Persist learning style results to Firestore
+- ⏳ Display results and next steps in Student Dashboard
+- ⏳ Connect “Generate Curriculum” flow (CrewAI) after assessment completion
 
-### Phase 4: Enhancement (Week 7-8)
-- [ ] Advanced Features
-  - [ ] Real-time collaboration
-  - [ ] Interactive exercises
-  - [ ] Peer learning features
-- [ ] Performance Optimization
-  - [ ] Caching implementation
-  - [ ] Load time optimization
-  - [ ] API efficiency improvements
+---
 
-## Development Guidelines
+## Data Model (Firestore)
 
-### Code Organization
+### parents/{parentUid}
+Recommended fields:
+- uid: string
+- email: string
+- displayName: string
+- students: string[] (array of student document IDs)
+- createdAt: ISO string
+- updatedAt: ISO string
+
+### students/{studentId}
+Recommended fields:
+- parentId: string (must match parent UID)
+- name: string
+- grade: string
+- hasTakenAssessment: boolean
+- learningStyle: "Visual" | "Auditory" | "Reading/Writing" | "Kinesthetic" | "Mixed" (optional)
+- assessmentStatus: "not_started" | "in_progress" | "completed" | "error" (optional)
+- assessmentResults: {
+    confidence: number,
+    rationale: string,
+    recommendations: string[]
+  } (optional)
+- createdAt: ISO string
+- updatedAt: ISO string
+
+### assessments/{assessmentId} (optional but recommended)
+Use this to store the full transcript + model outputs for audits and iteration:
+- studentId: string
+- parentId: string
+- messages: { role: "user"|"assistant", content: string }[]
+- result: { learningStyle, confidence, rationale, recommendations }
+- model: string
+- createdAt: ISO string
+
+---
+
+## Learning Style Assessment Architecture
+
+1) Student interacts with the chat UI (frontend)
+- The UI collects the conversation messages.
+- The UI submits them to the backend, not directly to any model provider.
+
+2) Backend endpoint performs security checks
+- Verify Firebase ID token (Authorization: Bearer <token>)
+- Load students/{studentId}
+- Enforce ownership: student.parentId must equal request.auth.uid
+
+3) Backend calls Vertex AI (Gemini on Vertex)
+- Provide a strict instruction to return ONLY valid JSON:
+  {
+    "learningStyle": "...",
+    "confidence": 0-1,
+    "rationale": "short text",
+    "recommendations": ["..."]
+  }
+- Validate JSON shape before saving.
+
+4) Backend persists the result
+- Update students/{studentId}:
+  - learningStyle
+  - hasTakenAssessment = true
+  - assessmentStatus = "completed"
+  - assessmentResults
+  - updatedAt
+- Optionally create assessments/{assessmentId} with transcript + result.
+
+---
+
+## Firestore Security Rules (Recommended Baseline)
+
+Note: these rules must match how the app reads/writes data.
+
+```js
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Parents can read/write their own profile.
+    match /parents/{parentId} {
+      allow read, write: if isSignedIn() && request.auth.uid == parentId;
+    }
+
+    // Students are owned by a parentId field.
+    match /students/{studentId} {
+      allow read: if isSignedIn() && request.auth.uid == resource.data.parentId;
+
+      // Create: parent creates a student and sets parentId to themselves
+      allow create: if isSignedIn()
+        && request.resource.data.parentId == request.auth.uid;
+
+      // Update/Delete: only the owning parent
+      allow update, delete: if isSignedIn()
+        && request.auth.uid == resource.data.parentId;
+    }
+
+    // Optional assessments collection
+    match /assessments/{assessmentId} {
+      allow read: if isSignedIn() && request.auth.uid == resource.data.parentId;
+      allow create: if isSignedIn() && request.resource.data.parentId == request.auth.uid;
+      allow update, delete: if false;
+    }
+  }
+}
+```
+
+---
+
+## Code Organization
+
 ```
 src/
-├── components/     # Reusable UI components
-├── pages/         # Route components
-├── contexts/      # React contexts
-├── services/      # API/Firebase services
-├── store/         # Redux store
-└── utils/         # Helpers and utilities
+├── components/
+├── pages/
+├── contexts/
+├── services/
+├── utils/
+└── types/
+
+server/                      # Node/Express backend (to add)
+├── src/
+│   ├── index.ts
+│   ├── routes/
+│   ├── middleware/
+│   └── services/
+├── package.json
+└── Dockerfile
 ```
 
-### Coding Standards
-- Use TypeScript for type safety
-- Follow ESLint configuration
-- Write unit tests for critical components
-- Document complex functions and components
+---
 
-### Git Workflow
-1. Create feature branch from `develop`
-2. Follow conventional commits
-3. Submit PR with description
-4. Require review approval
-5. Squash merge to `develop`
+## Local Development
 
-### Testing Strategy
-- Unit tests for utilities and hooks
-- Integration tests for major features
-- E2E tests for critical user flows
-- Regular security testing
-
-### Performance Targets
-- First Contentful Paint < 1.5s
-- Time to Interactive < 3s
-- Lighthouse score > 90
-- API response time < 200ms
-
-## Environment Setup
-
-### Development Environment
+### Frontend
 ```bash
-# Install dependencies
 npm install
-
-# Start development server
 npm run dev
-
-# Run tests
-npm test
-
-# Check types
-npm run type-check
 ```
 
-### Firebase Configuration
-Required environment variables:
+### Backend
+```bash
+cd server
+npm install
+npm run dev
+```
+
+### Vite Proxy (/api)
+Proxy `/api` to the local server so the frontend can call:
+
+```
+/api/learning-style/assess
+```
+
+Example `vite.config.ts` snippet:
+
+```ts
+server: {
+  proxy: {
+    '/api': 'http://localhost:8080'
+  }
+}
+```
+
+---
+
+## Environment Variables
+
+### Frontend Firebase (required)
 ```
 VITE_FIREBASE_API_KEY
 VITE_FIREBASE_AUTH_DOMAIN
@@ -125,51 +227,47 @@ VITE_FIREBASE_APP_ID
 VITE_FIREBASE_MEASUREMENT_ID
 ```
 
-### OpenAI Integration
-Required for chat features:
+### Backend (Cloud Run + Vertex AI)
+Use Secret Manager for sensitive values.
+
 ```
-VITE_OPENAI_API_KEY
-VITE_OPENAI_MODEL
+GOOGLE_CLOUD_PROJECT
+VERTEX_REGION
+VERTEX_MODEL
+FIREBASE_PROJECT_ID
 ```
 
-## Deployment
+Important:
+- Do NOT put model provider keys in VITE_ variables.
+- All model calls must go through the backend.
 
-### Staging Deployment
-1. Merge to `develop`
-2. Automatic deployment to staging
-3. Run integration tests
-4. Manual QA review
+---
 
-### Production Deployment
-1. Create release branch
-2. Version bump
-3. Generate changelog
-4. Deploy to production
-5. Tag release
+## Deployment Notes
+
+### Cloud Run
+- Build and deploy the Express backend to Cloud Run.
+- Run Cloud Run as a service account with Vertex AI permissions.
+- Use Secret Manager for config and rotate as needed.
+- Rely on Application Default Credentials (ADC) for service authentication.
+
+---
 
 ## Monitoring
+- Cloud Run logs for backend
+- Firebase logs for client events (optional)
+- Add Sentry later for client error tracking
+- Add structured backend request IDs for traceability
 
-### Key Metrics
-- User engagement metrics
-- Learning effectiveness
-- System performance
-- Error rates
+---
 
-### Logging
-- Application logs in Firebase
-- Error tracking in Sentry
-- Performance monitoring in Firebase Performance
-
-## Support and Documentation
-
-### Internal Resources
-- API Documentation
-- Component Storybook
-- Architecture diagrams
-- Test coverage reports
-
-### External Resources
-- [React Documentation](https://react.dev)
-- [Firebase Documentation](https://firebase.google.com/docs)
-- [OpenAI API Reference](https://platform.openai.com/docs)
-- [TypeScript Handbook](https://www.typescriptlang.org/docs/)
+## Testing Strategy
+- Unit tests for services (profileService, learningStyleService)
+- Integration tests for:
+  - Auth middleware
+  - Assessment endpoint authorization checks
+  - Firestore write behavior
+- E2E tests later for:
+  - Parent creates student
+  - Student completes assessment
+  - Parent sees result

--- a/Developmentplan.md
+++ b/Developmentplan.md
@@ -1,35 +1,90 @@
 # Development Plan
 
 ## Project Overview
-Geaux Academy is an innovative educational platform designed to provide personalized learning experiences for students. The platform leverages advanced technologies such as AI and machine learning to tailor educational content to individual learning styles, ensuring that each student can learn at their own pace and in their own way.
+Geaux Academy provides personalized learning for K-12 students through a parent-led workflow:
+1) Parent creates a Student Profile.
+2) Student completes an AI-guided Learning Style Assessment.
+3) The platform generates grade-appropriate curriculum and activities aligned to the student’s learning style.
+4) Parent approves curriculum before it reaches the student.
+5) Student progress is tracked and surfaced to the parent with insights and interventions.
 
-## Goals
-1. **Personalized Learning Paths**: Develop a system that creates customized learning paths for each student based on their unique learning style and progress.
-2. **Interactive Content**: Integrate interactive and engaging content to enhance the learning experience.
-3. **Progress Tracking**: Implement a robust progress tracking system to monitor student performance and provide feedback.
-4. **Scalability**: Ensure the platform can scale to accommodate a growing number of users without compromising performance.
-5. **Security**: Implement strong security measures to protect user data and ensure privacy.
+## Core Goals
+1) Personalized Learning Paths
+- Generate learning paths based on grade + learning style + progress signals.
 
-## Milestones
-1. **MVP Launch** (Q1 2023)
-   - Complete core features: personalized learning paths, interactive content, and progress tracking.
-   - Conduct initial user testing and gather feedback.
-2. **User Feedback Integration** (Q2 2023)
-   - Analyze user feedback and make necessary improvements.
-   - Enhance user interface and user experience based on feedback.
-3. **Scalability Improvements** (Q3 2023)
-   - Optimize the platform for scalability.
-   - Implement load testing and performance enhancements.
-4. **Security Enhancements** (Q4 2023)
-   - Conduct a comprehensive security audit.
-   - Implement additional security measures based on audit findings.
-5. **Full Launch** (Q1 2024)
-   - Launch the fully optimized and secure platform to the public.
-   - Initiate marketing and user acquisition campaigns.
+2) Interactive Learning Experience
+- Keep lessons engaging and approachable with multi-modal activities.
 
-## Timeline
-- **Q1 2023**: MVP Launch
-- **Q2 2023**: User Feedback Integration
-- **Q3 2023**: Scalability Improvements
-- **Q4 2023**: Security Enhancements
-- **Q1 2024**: Full Launch
+3) Parent Oversight
+- Parents approve curriculum, see progress, and get actionable intervention guidance.
+
+4) Scalable Architecture
+- Cloud Run backend for AI and core APIs; Firestore for rapid iteration.
+
+5) Security and Privacy
+- Strong access controls, least-privilege IAM, no AI keys on the client.
+
+---
+
+## Phased Roadmap
+
+### Phase 1: Foundation and Identity (Mostly Done)
+- [x] React + Vite + Firebase Auth setup
+- [x] Email/password login flow stable
+- [x] Parent Dashboard route gating
+- [x] Student creation from Parent Dashboard
+- [x] Student Dashboard loads and begins assessment UI
+
+Deliverable:
+- Parent can create student and reach student dashboard reliably.
+
+### Phase 2: Assessment Backend and Persistence
+- [ ] Node/Express backend scaffold in `/server`
+- [ ] Firebase Admin token verification middleware
+- [ ] Vertex AI integration wrapper (Gemini on Vertex)
+- [ ] POST /api/learning-style/assess endpoint
+- [ ] Save results to Firestore students/{studentId}
+- [ ] Assessment results UI (student view + parent view)
+
+Deliverable:
+- Assessment produces stored learning style + recommendations with confidence and rationale.
+
+### Phase 3: Curriculum Generation and Parent Approval (CrewAI)
+- [ ] Curriculum generation service (CrewAI or equivalent orchestration)
+- [ ] “Generate Curriculum” trigger only after assessment completion
+- [ ] Parent Approval workflow:
+  - approve/reject/edit
+  - versioning and history
+- [ ] Store curriculum artifacts per student and per term
+
+Deliverable:
+- Parent receives a proposed curriculum aligned to grade + learning style and can approve it.
+
+### Phase 4: Progress Tracking and Insights
+- [ ] Assignment/task model (daily/weekly lessons)
+- [ ] Student completion tracking
+- [ ] Parent insights:
+  - progress summaries
+  - struggle areas
+  - suggested interventions and pacing adjustments
+- [ ] Basic analytics (completion rates, topic mastery signals)
+
+Deliverable:
+- Parent dashboard shows progress and meaningful “what to do next” guidance.
+
+### Phase 5: Hardening and Scale
+- [ ] Security review (rules, IAM, token handling, logging)
+- [ ] Performance improvements and caching
+- [ ] Cost controls for model usage
+- [ ] Observability (Sentry, structured logs, alerts)
+- [ ] CI checks and deployment workflows
+
+Deliverable:
+- Stable, secure, cost-aware system ready for broader rollout.
+
+---
+
+## Key Risks and Mitigations
+- AI output reliability: enforce strict JSON schema and validation.
+- Cost creep: rate limit, cache, and keep inference server-side.
+- Access control: double-enforce in Firestore rules and backend checks.


### PR DESCRIPTION
### Motivation
- Bring docs in line with the current implementation and planned backend (email/password auth works, student creation and UI present, assessment chat needs a server-side backend).
- Replace outdated Python/FastAPI/OpenAI frontend guidance with a server-side Vertex AI (Gemini on Vertex) plan to avoid model keys on the client.
- Define a clear data model, Firestore rules, and ownership checks so assessment results are stored securely and auditable.
- Provide a concrete, short-term implementation checklist to make next-day work productive.

### Description
- Replaced `DEVELOPMENT_GUIDE.md` content to describe a Node.js + Express API deployed to Google Cloud Run, Vertex AI usage, Firestore data model for `parents`, `students`, and `assessments`, recommended Firestore rules, and local dev + deployment notes.
- Reworked `Developmentplan.md` into a phase-based roadmap (Phase 1..5) aligned to current progress and realistic implementation milestones, removing old dated timeline entries.
- Added `Assessment_Roadmap.md` with a step-by-step checklist for GCP prerequisites, local `server/` scaffolding, Firebase Admin token verification middleware, Vertex AI wrapper, Firestore writes, Cloud Run deploy steps, and smoke tests/troubleshooting.
- Emphasized security guidance: no model keys in `VITE_` variables, use Secret Manager, service account roles, JSON schema enforcement for model outputs, and backend ownership checks before Firestore writes.

### Testing
- No automated tests were run because these are documentation-only changes.
- Documentation updates were committed to the repository; CI will run on merge according to repo workflows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954fcc651148326bcc7fd8f522ad16a)