### PR TITLE
Fix parent dashboard student ids and card rendering

### DIFF
--- a/src/pages/profile/ParentProfile/ParentDashboard.tsx
+++ b/src/pages/profile/ParentProfile/ParentDashboard.tsx
@@ -66,7 +66,11 @@ const ParentDashboard: React.FC = () => {
     }
   };
 
-  const handleProfileSwitch = (studentId: string) => {
+  const handleProfileSwitch = (studentId?: string) => {
+    if (!studentId) {
+      console.warn('Student ID is missing, unable to navigate to student dashboard.');
+      return;
+    }
     setSelectedStudent(studentId);
     navigate(`/student-dashboard/${studentId}`);
   };
@@ -103,12 +107,12 @@ const ParentDashboard: React.FC = () => {
                 <StatusMessage>No students yet. Add your first student to get started.</StatusMessage>
               )}
               {!studentsLoading && !studentsError && parentProfile?.students?.map((student) => (
-                <StudentCard key={student.id} onClick={() => handleProfileSwitch(student.id)}>
-                  <h3>{student.name}</h3>
-                  <p>Grade: {student.grade}</p>
+                <StudentCardTile key={student.id} onClick={() => handleProfileSwitch(student.id)}>
+                  <h3>{student.name || 'Unnamed student'}</h3>
+                  <p>Grade: {student.grade || 'Not provided'}</p>
                   <p>Assessment: {student.hasTakenAssessment ? 'Completed' : 'Pending'}</p>
                   <ViewProfileButton>View Profile</ViewProfileButton>
-                </StudentCard>
+                </StudentCardTile>
               ))}
             </StudentList>
           </StudentManagement>
@@ -199,7 +203,7 @@ const StatusMessage = styled.div`
   text-align: center;
 `;
 
-const StudentCard = styled.div`
+const StudentCardTile = styled.div`
   background: #f8fafc;
   padding: 1rem;
   border-radius: 4px;

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -143,13 +143,14 @@ export const getStudentsByIds = async (ids: string[]): Promise<Student[]> => {
       const studentRef = doc(firestore, 'students', studentId);
       const studentDoc = await getDoc(studentRef);
       if (!studentDoc.exists()) {
+        console.warn(`Student document not found for id: ${studentId}`);
         return null;
       }
 
       const studentData = studentDoc.data() as Student;
       const studentProfile = {
         ...studentData,
-        id: studentData.id || studentId
+        id: studentDoc.id
       };
       profileCache.set(cacheKey, studentProfile);
       return studentProfile;


### PR DESCRIPTION
### Motivation
- Ensure student objects returned to the ParentDashboard always include the Firestore document `id` to avoid undefined `student.id` in the UI.
- Prevent a local styled component name collision with the shared `StudentCard` component by renaming the local symbol.
- Guard navigation and rendering so missing or incomplete student data does not crash the dashboard or produce empty UI.

### Description
- Updated `src/services/profileService.ts` `getStudentsByIds` to use `getDoc` per id, log a warning when a student doc is missing, set `id` to `studentDoc.id`, cache the profile, and preserve ordering for found students.
- Updated `src/pages/profile/ParentProfile/ParentDashboard.tsx` to rename the styled `StudentCard` to `StudentCardTile` and replace all usages accordingly to avoid collisions with `src/components/student/StudentCard.tsx`.
- Made `handleProfileSwitch` accept an optional `studentId` and early-return with a warning when `studentId` is missing to prevent navigation crashes, and rendered student `name`/`grade` defensively with fallback text while keeping assessment status rendering via `hasTakenAssessment`.
- No type changes were required because the `Student` interface in `src/types/profiles.ts` already includes `id: string`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69562aea780483268632ce8ab2919023)