### PR TITLE
Handle missing student profiles in StudentDashboard and add setup CTAs

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -43,7 +43,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [isAuthReady, setIsAuthReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const redirectHandledRef = useRef(false);
-  const isDev = import.meta.env.DEV;
+  const isDev =
+    typeof window !== 'undefined' && window.location.hostname === 'localhost';
 
   useEffect(() => {
     if (isDev) {

--- a/src/pages/__tests__/StudentDashboard.test.tsx
+++ b/src/pages/__tests__/StudentDashboard.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import StudentDashboard from "../profile/StudentProfile/StudentDashboard";
+import { getStudentProfile } from "../../services/profileService";
+
+const mockNavigate = jest.fn();
+const mockUseParams = jest.fn();
+const mockUseAuth = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => mockUseParams()
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth()
+}));
+
+jest.mock('../../services/profileService', () => ({
+  getStudentProfile: jest.fn()
+}));
+
+describe('StudentDashboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders setup state when student id is missing and user is authenticated', () => {
+    mockUseParams.mockReturnValue({ id: undefined });
+    mockUseAuth.mockReturnValue({ currentUser: { uid: 'parent-123' } });
+
+    render(<StudentDashboard />);
+
+    expect(screen.getByRole('heading', { name: /student profile not found/i })).toBeInTheDocument();
+    expect(screen.getByText(/needs a student profile before it can load/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /back to parent dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add student/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(getStudentProfile).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /back to parent dashboard/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/parent-dashboard');
+
+    fireEvent.click(screen.getByRole('button', { name: /add student/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/create-student');
+  });
+
+  test('renders setup state with login CTA when user is not authenticated', () => {
+    mockUseParams.mockReturnValue({ id: undefined });
+    mockUseAuth.mockReturnValue({ currentUser: null });
+
+    render(<StudentDashboard />);
+
+    expect(screen.getByRole('heading', { name: /student profile not found/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go to login/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add student/i })).not.toBeInTheDocument();
+    expect(getStudentProfile).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /go to login/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the StudentDashboard from crashing when the `:id` route param is missing or the student profile document is not found.  
- Provide clear setup/empty-state CTAs so parents (or unauthenticated users) can recover (add a student, go back to parent dashboard, or login).  
- Ensure `LearningStyleChat` can be safely used inside the dashboard by passing an explicit `studentId` prop.  
- Make dev-logging usable in the test environment by avoiding `import.meta` usage that breaks Jest.

### Description
- Robust `studentId` handling: StudentDashboard now treats a missing or empty `id` route param as a setup state (no fallback to `currentUser.uid`) and only fetches when an `id` exists using the existing `fetchWithTimeout`.  
- Setup/empty UI and CTAs: replaced previous setup view with a friendly card that shows the title `Student profile not found`, explanatory copy, and three CTAs: primary `Back to Parent Dashboard` (falls back to `/dashboard`), secondary `Add Student` (navigates to `/create-student`, shown only when authed), and tertiary `Retry` (calls `handleRetry`).  
- Error state improvements and safe rendering: error view now includes a back/login CTA and retry, and the main dashboard view will not render unless `studentData` is present (if `studentData` is null after loading it shows the setup card).  
- LearningStyleChat safety and small infra change: `LearningStyleChat` is passed `studentId={studentData.id ?? id}` from the dashboard, `AuthContext` and dashboard dev-logging were switched from `import.meta.env.DEV` to a hostname-based `isDev` guard to avoid `import.meta` in Jest, and the test dependency on `currentUser` was decoupled from fetch logic by removing `currentUser` from the dashboard effect deps.
- Files changed: `src/pages/profile/StudentProfile/StudentDashboard.tsx`, `src/contexts/AuthContext.tsx`, and added test `src/pages/__tests__/StudentDashboard.test.tsx`.

### Testing
- Added unit test `src/pages/__tests__/StudentDashboard.test.tsx` which mocks `useParams` and `useAuth` to assert the setup UI and CTA behavior when `id` is missing.  
- Ran `npm test -- StudentDashboard.test.tsx` to execute the new test, but the Jest run failed due to a missing test runtime dependency (`babel-plugin-styled-components`) in the environment causing Jest to error before the tests could run.  
- The earlier `import.meta` parsing errors were addressed by removing `import.meta` usage in `AuthContext` and replacing dashboard dev-logging; after that change Jest progressed to the Babel plugin error.  
- No other automated tests were run as part of this change due to the test environment error described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695639a09b5883268a4482566700498c)