### PR TITLE
docs: update roadmap after issues 135-138

### DIFF
--- a/Assessment_Roadmap.md
+++ b/Assessment_Roadmap.md
@@ -1,7 +1,17 @@
 # Assessment Roadmap
-Next Steps: Cloud Run Node/Express Backend + Vertex AI for Learning Style Assessment
+Status (Jan 1, 2026): ✅ Implemented in `ga-assessment-service` under `/server` (Issue #138).
 
-This file is the “tomorrow plan” to connect the student assessment chat UI to a secure backend, call Vertex AI, and persist results into Firestore.
+This file documents the assessment backend plan that has now been completed. Use it as a reference for setup, deployment, and follow-up wiring.
+
+## Completed Today (Jan 1, 2026)
+- Cloud Run-friendly TypeScript/Express service scaffolded in `/server`
+- Firebase ID token auth middleware + ownership checks (401/403/404 cases)
+- Endpoints:
+  - `POST /api/learning-style/assess`
+  - `POST /api/assessment/chat`
+- Firestore updates to `students/{studentId}` and best-effort writes to `assessments`
+- Vertex AI provider with stub fallback
+- Minimal tests for `/healthz` and missing-auth assessment request
 
 ---
 

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -22,6 +22,7 @@ Geaux Academy is a parent-led, student-focused learning platform:
 - Firebase Admin SDK for verifying Firebase ID tokens
 - Firestore for data persistence
 - Vertex AI (Gemini on Vertex) for Learning Style Assessment inference
+- Service name: ga-assessment-service
 - Optional future services:
   - CrewAI pipeline service for curriculum generation and validation
   - Background job runner (Cloud Tasks / PubSub) for async workloads
@@ -35,11 +36,14 @@ Geaux Academy is a parent-led, student-focused learning platform:
 - ✅ Parent Dashboard loads for authenticated users
 - ✅ Parent can create a student (Firestore permissions resolved)
 - ✅ Student Dashboard loads and begins the assessment chat UI
+- ✅ ParentDashboard shows student cards with Firestore-backed name/grade data
+- ✅ StudentDashboard handles missing/invalid student IDs with setup CTAs and tests
+- ✅ ga-assessment-service scaffold in `/server` with auth, ownership checks, and baseline tests
 
 ### In Progress
-- ⏳ Tie assessment chat to backend endpoint
-- ⏳ Persist learning style results to Firestore
-- ⏳ Display results and next steps in Student Dashboard
+- ⏳ Wire assessment chat to `/api/learning-style/assess`
+- ⏳ Display assessment results and next steps in Student Dashboard
+- ⏳ Surface assessment status + learning style in Parent Dashboard
 - ⏳ Connect “Generate Curriculum” flow (CrewAI) after assessment completion
 
 ---
@@ -168,7 +172,7 @@ src/
 ├── utils/
 └── types/
 
-server/                      # Node/Express backend (to add)
+server/                      # ga-assessment-service backend (Cloud Run)
 ├── src/
 │   ├── index.ts
 │   ├── routes/

--- a/Developmentplan.md
+++ b/Developmentplan.md
@@ -39,11 +39,11 @@ Deliverable:
 - Parent can create student and reach student dashboard reliably.
 
 ### Phase 2: Assessment Backend and Persistence
-- [ ] Node/Express backend scaffold in `/server`
-- [ ] Firebase Admin token verification middleware
-- [ ] Vertex AI integration wrapper (Gemini on Vertex)
-- [ ] POST /api/learning-style/assess endpoint
-- [ ] Save results to Firestore students/{studentId}
+- [x] Node/Express backend scaffold in `/server` (ga-assessment-service)
+- [x] Firebase Admin token verification middleware
+- [x] Vertex AI integration wrapper (Gemini on Vertex)
+- [x] POST /api/learning-style/assess endpoint
+- [x] Save results to Firestore students/{studentId}
 - [ ] Assessment results UI (student view + parent view)
 
 Deliverable:


### PR DESCRIPTION
### Motivation
- Ensure the project roadmap and top-level documentation reflect the work completed on Jan 1, 2026 (issues #135–#138).
- Surface the new backend scaffold and UX improvements so contributors know where to run and deploy the service.
- Make it explicit which issues are completed and which items remain to keep planning aligned with code changes.

### Description
- Updated `README.md` with a "Status / Progress" section, a "What we finished today (Jan 1, 2026)" list, a "Today's Changes" file summary, and a `/server` (ga-assessment-service) run/deploy guide and endpoints list.
- Marked assessment/backend work complete in `Assessment_Roadmap.md` and recorded the implemented endpoints, auth expectations, Firestore write behavior, and provider fallback behavior.
- Updated `DEVELOPMENT_GUIDE.md` to reference the service name `ga-assessment-service`, reflect completed items (ParentDashboard/StudentDashboard/assessment scaffold), and adjust in-progress tasks.
- Updated `Developmentplan.md` to mark the Phase 2 assessment backend tasks as completed and keep the remaining UI work as in-progress.

### Testing
- No automated tests were run as part of this PR because the changes are documentation-only.
- The repo contains minimal `vitest`+`supertest` coverage for the new service endpoints (`/healthz` and missing-auth assessment request), but those tests were not executed in this docs update.
- Manual verification checklist is provided in the README to confirm links, local run commands, and endpoint expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564db8af5c8326aebb7f8239331d40)